### PR TITLE
Support custom transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node lib/test/server",
     "pretest": "npm run build",
     "test": "with-server tap lib/test/client.js",
-    "prepare": "npm run build"
+    "prepare": "npm install && npm run build"
   },
   "author": "Felix Gnass <fgnass@gmail.com>",
   "repository": "fgnass/typed-rpc",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node lib/test/server",
     "pretest": "npm run build",
     "test": "with-server tap lib/test/client.js",
-    "prepublish": "npm run build"
+    "postinstall": "npm run build"
   },
   "author": "Felix Gnass <fgnass@gmail.com>",
   "repository": "fgnass/typed-rpc",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node lib/test/server",
     "pretest": "npm run build",
     "test": "with-server tap lib/test/client.js",
-    "postinstall": "npm install && npm run build"
+    "prepare": "npm run build"
   },
   "author": "Felix Gnass <fgnass@gmail.com>",
   "repository": "fgnass/typed-rpc",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node lib/test/server",
     "pretest": "npm run build",
     "test": "with-server tap lib/test/client.js",
-    "prepare": "npm install && npm run build"
+    "prepare": "npm run build"
   },
   "author": "Felix Gnass <fgnass@gmail.com>",
   "repository": "fgnass/typed-rpc",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node lib/test/server",
     "pretest": "npm run build",
     "test": "with-server tap lib/test/client.js",
-    "postinstall": "npm run build"
+    "postinstall": "npm install && npm run build"
   },
   "author": "Felix Gnass <fgnass@gmail.com>",
   "repository": "fgnass/typed-rpc",

--- a/src/test/client.ts
+++ b/src/test/client.ts
@@ -1,24 +1,25 @@
+import "isomorphic-fetch";
+import tap from "tap";
 import { rpcClient, RpcError } from "../client.js";
 import { Service } from "./service.js";
-import tap from "tap";
-import "isomorphic-fetch";
 
 const apiUrl = process.env.SERVER_URL + "/api";
 
 tap.test("should talk to the server", async (t) => {
-  const client = rpcClient<Service>(apiUrl);
+  const client = rpcClient<Service>({ url: apiUrl });
   const result = await client.hello("world");
   t.equal(result, "Hello world!");
 });
 
 tap.test("should omit trailing undefined params", async (t) => {
-  const client = rpcClient<Service>(apiUrl);
+  const client = rpcClient<Service>({ url: apiUrl });
   const result = await client.greet("hello", undefined);
   t.equal(result, "hello world!");
 });
 
 tap.test("should override headers", async (t) => {
-  const client = rpcClient<Service>(apiUrl, {
+  const client = rpcClient<Service>({
+    url: apiUrl,
     getHeaders() {
       return {
         "Prefer-Status": "400",
@@ -30,22 +31,20 @@ tap.test("should override headers", async (t) => {
 });
 
 tap.test("should echo headers", async (t) => {
-  const client = rpcClient<Service>(
-    process.env.SERVER_URL + "/request-aware-api",
-    {
-      getHeaders() {
-        return {
-          "X-Hello": "world",
-        };
-      },
-    }
-  );
+  const client = rpcClient<Service>({
+    url: process.env.SERVER_URL + "/request-aware-api",
+    getHeaders() {
+      return {
+        "X-Hello": "world",
+      };
+    },
+  });
   const res = await client.echoHeader("X-Hello");
   t.equal(res, "world");
 });
 
 tap.test("should throw on errors", async (t) => {
-  const client = rpcClient<Service>(apiUrl);
+  const client = rpcClient<Service>({ url: apiUrl });
   const promise = client.sorry("Dave");
   t.rejects(promise, new RpcError("Sorry Dave.", -32000));
 });


### PR DESCRIPTION
Hi, I recently used this wonderful library for my own project but found out that I need some modifications:

- My project uses custom WebSocket transport instead of fetch
- Another use case is for Electron IPC calls

Both would require a custom transport other than `fetch`. I have implemented supporting overriding default transport (and to do that, I make the public interface a bit more consistent). Not sure if you want to merge this as you might consider it out of the scope of your project. I am happy to maintain a fork for my use case regardless.

Cheers.