### PR TITLE
Remove console.log on missing method

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -112,7 +112,6 @@ export async function handleRpc<T extends RpcService<T>>(
   }
   const { jsonrpc, method, params } = request;
   if (!hasMethod(service, method)) {
-    console.log("Method %s not found", method, service);
     return {
       jsonrpc,
       id,


### PR DESCRIPTION
This simply removes the `console.log` call on missing methods.

Fixes #15.