### PR TITLE
Update name of RpcError in stack traces

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ export class RpcError extends Error {
 
   constructor(message: string, code: number, data?: unknown) {
     super(message);
+    this.name = "RpcError";
     this.code = code;
     this.data = data;
     // https://www.typescriptlang.org/docs/handbook/2/classes.html#inheriting-built-in-types


### PR DESCRIPTION
This makes it easier to debug whether or not an error comes from the RPC client.

