### PR TITLE
Handle undefined 'data' property on error

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -50,7 +50,11 @@ function getErrorMessage(err: unknown) {
 
 function getErrorData(err: unknown) {
   if (hasProperty(err, "data")) {
-    return (err.data = JSON.parse(JSON.stringify(err.data)));
+      const stringifiedData = JSON.stringify(err.data);
+      if (stringifiedData !== undefined) {
+          err.data = JSON.parse(stringifiedData);
+      }
+      return err.data;
   }
 }
 


### PR DESCRIPTION
Hi. I have a case where I got an error from a service method containing an undefined `data` property.
This leads to problems when `handleRpc` calls `getErrorData`, since `undefined` is not JSON-serializable, and error handling breaks down.
My fix handles all data that cannot be serialized, not just the `undefined` value.
