### PR TITLE
fix: allow params to be undefined

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -130,13 +130,18 @@ export function rpcClient<T extends object>(options: RpcClientOptions) {
 /**
  * Create a JsonRpcRequest for the given method.
  */
-export function createRequest(method: string, params: any[]): JsonRpcRequest {
-  return {
+export function createRequest(method: string, params?: any[]): JsonRpcRequest {
+  const req: JsonRpcRequest = {
     jsonrpc: "2.0",
     id: Date.now(),
     method,
-    params: removeTrailingUndefs(params),
   };
+
+  if (params?.length) {
+    req.params = removeTrailingUndefs(params);
+  }
+
+  return req;
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ export * from "./types.js";
 export function isJsonRpcRequest(req: any): req is JsonRpcRequest {
   if (req.jsonrpc !== "2.0") return false;
   if (typeof req.method !== "string") return false;
-  if (!Array.isArray(req.params)) return false;
+  if (!Array.isArray(req.params) && req.params !== undefined) return false;
   return true;
 }
 
@@ -141,7 +141,7 @@ export async function handleRpc<T extends RpcService<T, V>, V = JsonValue>(
     });
   }
   try {
-    const result = await service[method as keyof T](...params);
+    const result = await service[method as keyof T](...params ?? []);
     return res({ result });
   } catch (err) {
     if (options?.onError) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export interface JsonRpcRequest {
   jsonrpc: "2.0";
   id?: string | number | null;
   method: string;
-  params: any[];
+  params?: any[];
 }
 
 export interface BaseJsonRpcResponse {


### PR DESCRIPTION
Allow `params` to be missing and remove an empty list from the request to follow the [specification](https://www.jsonrpc.org/specification):

> `params`
> A Structured value that holds the parameter values to be used during the invocation of the method. This member MAY be omitted.
