### PR TITLE
Add notify callback support

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -28,3 +28,5 @@ export type RpcTranscoder<T> = {
   serialize: (data: T) => any;
   deserialize: (data: any) => T;
 };
+
+export const NOTIFY_MARKER = '__notify__';


### PR DESCRIPTION
@fgnass thanks for the great library!

I'm not suggesting this PR is merged because it...

- Extends the project scope too far
- Abuses the JSON RPC specification somewhat

However, I wanted to use this feature as a request for an extension point.

# What it does

The changes here allow callback functions in the service description which covers our use case of returning stream data (e.g. progress) before an RPC is considered complete.
Using JSON RPC as a base for this as its being used inside an electron app over IPC and approaches such as gRPC are a little heavy.

# Usage

## Service

```typescript
// Service
export const service = {
    async run(args: string[], onData: (data: string) => void) {
        let success = false;
        const result = await new Promise((resolve, reject) => {
            const process = spawn(BINARY_FILE, args);
            process.stdout?.on('data', data => onData(data.toString()));
            process.on('error', reject);
            process.on('close', code => resolve(code));
        })
        success = result === 0;
        return success;
    }
};
export type Service = typeof service;
...

// Handler
export const handler = async (raw: any) => {
  let result = await handleRpc(raw, service, { onNotify: result => sendMessage(result) });
  sendMessage(result);
};
```

## Client

```typescript
// Transport
export const transport = async (req: JsonRpcRequest, _signal: AbortSignal, notify: (result: any) => boolean): Promise<any> => {
  sendMessage(req);

  const result = await new Promise(resolve => {
    port.addEventListener('message', function listener(e: MessageEvent) {
      const end = notify(e.data);
      if (end) {
        port.removeEventListener('message', listener);
        resolve(e.data);
      }
    });
  });

  return result;
};
...

// Client
export const client = {
  service: rpcClient<Service>({ url: '', transport })
};
...

// Usage
const success = await client.service.run(args, data => console.log(data));
console.log(success);
```

# Ask

I've forked this library to add this feature as I couldn't use the existing extension points to add it. I'm keen to not do this, do you see a way to add an API to allow such extension?