### PR TITLE
feat: support notifications

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -30,7 +30,7 @@ export class RpcError extends Error {
 export type RpcTransport = (
   req: JsonRpcRequest,
   abortSignal: AbortSignal
-) => Promise<JsonRpcResponse>;
+) => Promise<JsonRpcResponse | void>;
 
 type RpcClientOptions =
   | string
@@ -90,7 +90,7 @@ export function rpcClient<T extends object>(options: RpcClientOptions) {
     throw new TypeError("Invalid response");
   };
 
-  async function sendNotification(method: string, ...args: any[]): Promise<Promise<any>> {
+  async function sendNotification(method: string, ...args: any[]): Promise<Promise<void>> {
     const req = createRequest(undefined, method, args);
     const ac = new AbortController();
     const promise = transport(serialize(req as any), ac.signal);
@@ -101,7 +101,7 @@ export function rpcClient<T extends object>(options: RpcClientOptions) {
         abortControllers.delete(promise);
       })
       .catch(() => {});
-    return promise;
+    return promise as Promise<void>;
   }
 
   // Map of AbortControllers to abort pending requests

--- a/src/test/client.ts
+++ b/src/test/client.ts
@@ -116,3 +116,28 @@ tap.test("should not relay internal methods", async (t) => {
   //@ts-expect-error
   client[Symbol()];
 });
+
+tap.test("should not notify", async (t) => {
+  let client: ReturnType<typeof rpcClient<Service>>;
+
+  const request = new Promise((resolve) => {
+    client = rpcClient<Service>({
+      url: 'n/a',
+      transport: async (req) => {
+        resolve(req);
+      },
+    });
+  });
+
+  const res = await Promise.all([
+    client!.$notify("hello", "world"),
+    request,
+  ]);
+  t.equal(res[0], undefined);
+  t.same(res[1], {
+    "jsonrpc": "2.0",
+    "method": "hello",
+    "params": ["world"],
+    // no id
+  });
+});


### PR DESCRIPTION
Allow sending json-rpc 2.0 notifications: basically requests without an id which do not await a response.