### PR TITLE
Ensure that the rpcClient object is not treated as a promise

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -161,6 +161,7 @@ export function rpcClient<T extends object>(options: RpcClientOptions) {
         return Reflect.get(target, prop, receiver);
       }
       if (typeof prop === "symbol") return;
+      if (prop === "then") return; // make sure we are not treated as a Promise
       if (prop === "toJSON") return;
       return (...args: any) => {
         const ac = new AbortController();

--- a/src/test/e2e.ts
+++ b/src/test/e2e.ts
@@ -37,7 +37,6 @@ function createWebSocketClient<T extends object>(options: {
   };
 }
 
-
 const url = process.env.SERVER_URL + "/api";
 globalThis.WebSocket = WS as any;
 

--- a/src/test/e2e.ts
+++ b/src/test/e2e.ts
@@ -42,13 +42,8 @@ const url = process.env.SERVER_URL + "/api";
 globalThis.WebSocket = WS as any;
 
 tap.test("should be able to initialize client asynchronously", async (t) => {
-  type RpcClientService = ReturnType<typeof rpcClient<Service>>;
-  async function clientFactory(): Promise<RpcClientService> {
-    return new Promise(r => r(rpcClient<Service>({ url })));
-  }
-
-  const factory = await clientFactory();
-  const client = factory;
+  const factory = async () => rpcClient<Service>({ url });
+  const client = await factory();
   const result = await client.hello("world");
   t.equal(result, "Hello world!");
 });

--- a/src/test/e2e.ts
+++ b/src/test/e2e.ts
@@ -37,8 +37,21 @@ function createWebSocketClient<T extends object>(options: {
   };
 }
 
+
 const url = process.env.SERVER_URL + "/api";
 globalThis.WebSocket = WS as any;
+
+tap.test("should be able to initialize client asynchronously", async (t) => {
+  type RpcClientService = ReturnType<typeof rpcClient<Service>>;
+  async function clientFactory(): Promise<RpcClientService> {
+    return new Promise(r => r(rpcClient<Service>({ url })));
+  }
+
+  const factory = await clientFactory();
+  const client = factory;
+  const result = await client.hello("world");
+  t.equal(result, "Hello world!");
+});
 
 tap.test("should talk to the server", async (t) => {
   const client = rpcClient<Service>(url);


### PR DESCRIPTION
I recently had a super-long debugging session that culminated in realizing that the proxy was swallowing the `then` calls that are performed automatically to interrogate the type of a return from an asynchronous function. See https://promisesaplus.com/ section 2.3.3 for details.

The solution ends up being quite simple; returning `undefined` when the proxy detects that `then` has been called on it.

This is quite a sinister bug; as it results in the method which returns the client appearing to simply... not return. Even with a debugger attached I was unable to step into and figure out exactly what was happening, and only noticed the stray "then" call in the logs of my API.